### PR TITLE
Security fixes, prep work for lockdown, better tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           # Add/remove versions from this list based on what you plan
           # to support for this module.
-          - 1.1.9
+          - 1.4.5
     steps:
       - name: 'checkout'
         uses: actions/checkout@v2

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -3,6 +3,6 @@ version: "1"
 module_version: 0.1.0-alpha.1
 runner_image: spacelift/runner:latest
 
-tests:
-  - name: Simple Usage
-    project_root: examples/simple-usage
+#tests:
+#  - name: Simple Usage
+#    project_root: examples/simple-usage

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ plan: clean
 	@terraform version \
 		&& cd "examples/simple-usage" \
 		&& terraform fmt --check \
-		&& terraform init \
+		&& HTTP_PROXY='' HTTPS_PROXY='' terraform init \
 		&& terraform validate \
 		&& terraform plan
 
@@ -35,7 +35,7 @@ unit-test: clean
 	@terraform version \
 		&& cd "examples/simple-usage" \
 		&& terraform fmt --check \
-		&& terraform init \
+		&& HTTP_PROXY='' HTTPS_PROXY='' terraform init \
 		&& terraform validate
 
 full-test: clean unit-test

--- a/README.md
+++ b/README.md
@@ -1,34 +1,22 @@
-# terraform-aws-s3-state-for-organization
+# terraform-aws-state-storage
 
-## DynamoDB locking
-
-For example, a stack with the name `aws/test/stack` will generate a DynamoDB entry with `LockID` being `tassfo-test-s2r4-main/aws/test/stack` and the following content.
-
-`LockID` is a standard used by the S3/DynamoDB Terraform [backend](https://www.terraform.io/language/settings/backends/s3#dynamodb-state-locking).
-
-> TODO: See if the "Who" can be better
-
-```json
-{
-  "ID": "15c87bd1-b189-4cb5-359d-746c71e3068e",
-  "Operation": "OperationTypeApply",
-  "Info": "",
-  "Who": "username@pop-os",
-  "Version": "1.2.7",
-  "Created": "2022-08-25T04:08:31.335995976Z",
-  "Path": "tassfo-test-s2r4-main/aws/test/stack"
-}
-```
+- A main S3 State Bucket that requires encrypted communication
+- A backup S3 State Bucket (which can be in a different region)
+- Replication between the main and backup bucket
+- A role with limited access to manipulate state in the main S3 bucket, which can be assumed by specific AWS principals or SSO Permission-Sets.
+- DynamoDB State locking according to Terraform `backend "s3"` specs
 
 ## Terraform Syntax
+
+This is a sample snippet of what would be added to your Terraform stack in order to access state using this module setup.
 
 ```terraform
 terraform {
   backend "s3" {
-    role_arn       = "arn:aws:iam::988857891049:role/tassfo-test-s2r4-state"
-    bucket         = "tassfo-test-s2r4-main"
-    dynamodb_table = "tassfo-test-s2r4-locks"
-    key            = "aws/test/stack"
+    role_arn       = "arn:aws:iam::000000000000:role/state-bucket-test-s2r4-state"
+    bucket         = "state-bucket-test-s2r4-main"
+    dynamodb_table = "state-bucket-test-s2r4-locks"
+    key            = "example/prototype/test"
     region         = "us-east-1"
     encrypt        = true
     max_retries    = 2
@@ -36,7 +24,9 @@ terraform {
 }
 ```
 
-What's important here, is that the credentials can, but generally are not passed in here, and are pulled from the environment instead.  Also it **DOES NOT** rely on the following being present (for the state file management itself).
+Important thing to note about the block above, is that the credentials used to assume the `role_arn` are pulled from the environment.
+
+Blocks like the following, **DO NOT** have any relation to the above, meaning that the `aws` provider is not needed in order to access AWS S3 state.
 
 ```terraform
 terraform {
@@ -50,3 +40,58 @@ terraform {
 }
 ```
 
+Likewise, the credentials in the block below are also not related to the `backend "s3"` block.
+
+```terraform
+provider "aws" {
+  region      = "someregion"
+  access_key  = "123"
+  secret_key  = "456"
+  token       = "789"
+}
+```
+
+## DynamoDB locking
+
+For example, a stack with the name `example/prototype/test` will generate a DynamoDB entry with `LockID` being `state-bucket-test-s2r4-main/example/prototype/test` and the following content.
+
+`LockID` is a standard used by the S3/DynamoDB Terraform [backend](https://www.terraform.io/language/settings/backends/s3#dynamodb-state-locking).
+
+```json
+{
+  "ID": "15c87bd1-b189-4cb5-359d-746c71e3068e",
+  "Operation": "OperationTypeApply",
+  "Info": "",
+  "Who": "username@pop-os",
+  "Version": "1.2.7",
+  "Created": "2022-08-25T04:08:31.335995976Z",
+  "Path": "state-bucket-test-s2r4-main/example/prototype/test"
+}
+```
+
+### What do I do if the statefile lock was not released?
+
+```bash
+# The ID would show up in the error message you get when trying to run terraform
+terraform force-unlock <ID>
+```
+
+> **PLEASE be sure that the statefile lock was yours!**
+
+Sample Error:
+
+```text
+Acquiring state lock. This may take a few moments...
+╷
+│ Error: Error acquiring the state lock
+│ 
+│ Error message: ConditionalCheckFailedException: The conditional request failed
+│ Lock Info:
+│   ID:        6b0b048e-5cf4-c88b-667e-4522ccf65659
+│   Path:      state-bucket-test-s2r4-main/example/prototype/test
+│   Operation: OperationTypeApply
+│   Who:       phadviger@pop-os
+│   Version:   1.2.7
+│   Created:   2022-09-08 10:50:46.24286514 +0000 UTC
+│   Info:      
+```

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,5 +1,6 @@
 resource "aws_dynamodb_table" "locks" {
-  name         = "${var.name}-locks"
+  provider     = aws.primary
+  name         = "${local.name}-locks"
   billing_mode = "PAY_PER_REQUEST"
 
   # https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table

--- a/examples/simple-usage/main.tf
+++ b/examples/simple-usage/main.tf
@@ -6,7 +6,7 @@ resource "random_string" "sample" {
 
 locals {
   name = "tassfo-test"
-  id = random_string.sample.id
+  id   = random_string.sample.id
   tags = {
     # Use any tags that are applicable and not already covered by default_tags
     Owner          = "DevOps"

--- a/examples/simple-usage/main.tf
+++ b/examples/simple-usage/main.tf
@@ -5,6 +5,7 @@ resource "random_string" "sample" {
 }
 
 locals {
+  name = "tassfo-test"
   id = random_string.sample.id
   tags = {
     # Use any tags that are applicable and not already covered by default_tags
@@ -24,10 +25,10 @@ module "target" {
   # this module requires two providers since the main and backup state buckets
   #   are meant to be located in different regions.
   providers = {
-    aws.primary   = aws
+    aws.primary   = aws.use1
     aws.secondary = aws.usw2
   }
-  name = "tassfo-test-${local.id}"
+  name = "${local.name}-${local.id}"
   tags = local.tags
 
   # The permission sets that should be able to assume role to access the state
@@ -39,16 +40,20 @@ module "target" {
   ]
   # NOTE: These have to be existing and valid roles
   aws_principal_arn = [
-    aws_iam_role.test_role.arn
+    aws_iam_role.this["temp"].arn
   ]
+
+  iac_principal_arn = aws_iam_role.this["iac"].arn
 }
 
 output "all" {
   value = module.target
 }
 
-resource "aws_iam_role" "test_role" {
-  name_prefix = "tassfo-test-${local.id}-"
+resource "aws_iam_role" "this" {
+  provider    = aws.use1
+  for_each    = toset(["iac", "temp"])
+  name_prefix = "${local.name}-${local.id}-${each.key}-"
   tags        = local.tags
 
   assume_role_policy = jsonencode({
@@ -58,7 +63,7 @@ resource "aws_iam_role" "test_role" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          AWS = "198604607953"
+          AWS = "000000000000"
         }
       },
     ]

--- a/examples/simple-usage/provider.tf
+++ b/examples/simple-usage/provider.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 4.27.0"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.1"
+      version = "~> 3.0"
     }
   }
 }
@@ -20,28 +20,27 @@ locals {
 }
 
 provider "aws" {
+  max_retries = 2
+  region      = "invalid"
+  access_key  = "invalid"
+  secret_key  = "invalid"
+  token       = "invalid"
+}
+
+provider "aws" {
+  alias               = "use1"
   max_retries         = 2
   region              = "us-east-1"
-  allowed_account_ids = ["198604607953"]
+  allowed_account_ids = ["000000000000"]
 
-  default_tags {
-    tags = local.default_tags
-  }
-  #assume_role {
-  #  role_arn = "arn:aws:iam::198604607953:role/infrastructure-as-code-admin"
-  #}
+  default_tags { tags = local.default_tags }
 }
 
 provider "aws" {
   alias               = "usw2"
   max_retries         = 2
   region              = "us-west-2"
-  allowed_account_ids = ["198604607953"]
+  allowed_account_ids = ["000000000000"]
 
-  default_tags {
-    tags = local.default_tags
-  }
-  #assume_role {
-  #  role_arn = "arn:aws:iam::198604607953:role/infrastructure-as-code-admin"
-  #}
+  default_tags { tags = local.default_tags }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "state" {
   provider = aws.primary
-  name     = "${var.name}-state"
+  name     = "${local.name}-state"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -20,6 +20,9 @@ resource "aws_iam_role" "state" {
         "Condition" = {
           "ArnEquals" = {
             "aws:PrincipalArn" = local.permission_set_arn_list
+          },
+          "StringEquals" : {
+            "aws:PrincipalOrgID" : local.organization_id
           }
         }
       } : null),

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 data "aws_region" "primary" { provider = aws.primary }
 data "aws_caller_identity" "primary" { provider = aws.primary }
 data "aws_partition" "primary" { provider = aws.primary }
+data "aws_organizations_organization" "primary" { provider = aws.primary }
 locals {
   aws_primary = {
     region     = data.aws_region.primary.name
@@ -8,6 +9,7 @@ locals {
     dns_suffix = data.aws_partition.primary.dns_suffix
     partition  = data.aws_partition.primary.partition
   }
+  organization_id = data.aws_organizations_organization.primary.id
 }
 data "aws_region" "secondary" { provider = aws.secondary }
 data "aws_caller_identity" "secondary" { provider = aws.secondary }
@@ -22,9 +24,10 @@ locals {
 }
 
 locals {
+  name = trimspace(var.name)
   # S3 related variables
-  main_name   = "${var.name}-main"
-  backup_name = "${var.name}-backup"
+  main_name   = "${local.name}-main"
+  backup_name = "${local.name}-backup"
 
   # - Convert the permission set name to the wildcard ARN
   # - Due to permission sets being org wide unique, we don't care about the account_id

--- a/replication.tf
+++ b/replication.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "replication" {
   provider = aws.primary
-  name     = "${var.name}-replication"
+  name     = "${local.name}-replication"
   tags     = var.tags
 
   assume_role_policy = jsonencode({

--- a/variable.tf
+++ b/variable.tf
@@ -14,6 +14,21 @@ variable "tags" {
   default = {}
 }
 
+variable "iac_principal_arn" {
+  type        = string
+  description = <<-DOC
+  AWS Principal that will be setting up these resources.
+
+  Since the S3 buckets are created with resource based policies, setting
+  this principal will allow the IaC tool to still be able to update the
+  S3 buckets with infrastructure changes.
+  DOC
+  validation {
+    condition     = length(trimspace(var.iac_principal_arn)) >= 0
+    error_message = "The 'iac_principal_arn' cannot be null."
+  }
+}
+
 # Since Terraform does not allow validations across variables, just be
 #   aware that one of the two following variables needs to contain a value.
 #   - permission_set_name_list
@@ -30,7 +45,6 @@ variable "permission_set_name_list" {
   }
 }
 
-# TODO: exclude *
 variable "aws_principal_arn" {
   type        = list(string)
   default     = []

--- a/version.tf
+++ b/version.tf
@@ -1,19 +1,9 @@
-### OVERVIEW BEGIN
-# Refer to the 'Module Versioning' section in the README for more information
-### OVERVIEW END
 terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.27"
-
-      # The template recommendation is to write your module with a provider
-      #   that is supplied when the module is instantiated, vs using the
-      #   default provider.
-      # If you really need to use the default provider only, then please
-      #   the configuration_aliases below, and from anything in the examples/
-      #   directory.
       configuration_aliases = [
         aws.primary,
         aws.secondary,


### PR DESCRIPTION
- **Introduced new required `iac_principal_arn` variable, to allow IaC pipelines to operate on the bucket.**
- Makefile changes to have `HTTP_PROXY='' HTTPS_PROXY=''` for `terraform init` in order to make it co-exist better with `iamlive` in proxy mode.
- Fix: Added missing `provider` to `aws_dynamodb_table.locks` and also to the `examples/`
- Fix: Added default `aws` provider to tests in order to simulate the failures if somehow `provider` was missing from any resources.
- Fix: Added the missing `aws:PrincipalOrgID` check to the `aws_iam_role.state`
- Fix: Replaced uses of `var.name` with `local.name` which is properly trimmed
- Updates to `aws_s3_bucket_policy.main` and `aws_s3_bucket_policy.backup` to prepare for later restrictions
- Removed `lifecycle { prevent_destroy = false }` on the S3 bucket, because it effectively disabled any kind of IaC teardown.
- Updated documentation